### PR TITLE
RecentlyViewedSites 컴포넌트 랜더링 테스트

### DIFF
--- a/__test__/RecentlyViewedSites.test.js
+++ b/__test__/RecentlyViewedSites.test.js
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import { RecoilRoot } from "recoil";
+import loginState from "../lib/recoil/auth";
+import MainPage from "../pages";
+
+describe("RecentlyViewedSites", () => {
+  const useQuery = jest.spyOn(require("react-query"), "useQuery");
+
+  useQuery.mockImplementation(() => ({
+    data: {
+      recentlyVisitedSites: ["pageList"],
+    },
+  }));
+
+  it("if it's not logged in, recently viewed sites is not rendered", async () => {
+    const { container } = render(
+      <RecoilRoot>
+        <MainPage />
+      </RecoilRoot>,
+    );
+
+    expect(container).not.toHaveTextContent("Recently Viewed");
+  });
+
+  it("if it's logged in, recently viewed sites is rendered", async () => {
+    const { container } = render(
+      <RecoilRoot
+        initializeState={snap =>
+          snap.set(loginState, {
+            data: {
+              _id: "testId",
+              name: "testMan",
+              email: "test@example.com",
+              profileImageUrl: "testImageUrl",
+            },
+          })
+        }
+      >
+        <MainPage />
+      </RecoilRoot>,
+    );
+
+    expect(container).toHaveTextContent("Recently Viewed");
+  });
+});


### PR DESCRIPTION
## Task 📄

- [[테스트] Jest 이용 컴포넌트 유닛 테스트](https://www.notion.so/vanillacoding/Jest-e126709dbdeb4ee2b8f943db9bd61066)

## Description 💬

- 로그인 여부에 따른 RecentlyViewedSites 컴포넌트 랜더링 테스트

## Point 🔑

- Jest Mocking
