### PR TITLE
모바일 환경 접속 시 대응 추가

### DIFF
--- a/components/MobileDefense/index.jsx
+++ b/components/MobileDefense/index.jsx
@@ -1,0 +1,53 @@
+import Image from "next/image";
+import styled from "styled-components";
+
+function MobileDefense() {
+  return (
+    <Wrapper>
+      <Image
+        className="alert-image"
+        src={"/images/genie-logo.png"}
+        alt="brand-logo"
+        width={200}
+        height={150}
+      />
+      <Content>
+        Not supported in mobile environment. Please run it in a desktop
+        environment.
+      </Content>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: none;
+
+  @media only screen and (max-width: 767px) {
+    display: unset;
+    position: absolute;
+    z-index: 100000;
+    height: 100%;
+    background-color: white;
+    width: 100vw;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    top: 0;
+    left: 0;
+  }
+`;
+
+const Content = styled.span`
+  width: 100vw;
+  text-align: center;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 23px;
+  color: #7e80ff;
+  border-bottom: 1px solid #f4f4f4;
+  padding-bottom: 20px;
+`;
+
+export default MobileDefense;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import GlobalStyle from "../components/shared/GlobalStyle";
 import ErrorModal from "../components/ErrorModal";
 import Loading from "../components/Loading";
+import MobileDefense from "../components/MobileDefense";
 
 function MyApp({ Component, pageProps }) {
   const queryClient = new QueryClient({
@@ -37,6 +38,7 @@ function MyApp({ Component, pageProps }) {
             >
               <GlobalStyle />
               <GlobalModal />
+              <MobileDefense />
               <AppHeader />
               <Main>
                 <Container>
@@ -56,6 +58,10 @@ MyApp.propTypes = {
   pageProps: PropTypes.object,
 };
 
-const Main = styled.main``;
+const Main = styled.main`
+  @media only screen and (max-width: 767px) {
+    display: none;
+  }
+`;
 
 export default MyApp;


### PR DESCRIPTION
## Task 📄

## Description 💬

- 미디어쿼리를 활용하여 모바일 환경(767px 이하)일 경우 'Main' 태그를 보여주지 않도록 대응
- 모바일 환경에서 안내문구를 포함한 컴포넌트 렌더링

## Point 🔑

- 미디어쿼리의 활용
- 안내 문구가 적절한지
